### PR TITLE
Added the new linksfound endpoint

### DIFF
--- a/app/Http/Controllers/LinkFoundController.php
+++ b/app/Http/Controllers/LinkFoundController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\LinkFound;
+use App\Http\Transformers\LinkFoundTransformer;
+use App\Http\Controllers\Controller;
+use App\Http\Serializers\CustomDataArraySerializer;
+use Illuminate\Http\Request;
+use League\Fractal\Manager;
+use League\Fractal\Resource\Collection;
+use League\Fractal\Resource\Item;
+use DB;
+
+class LinkFoundController extends ApiController
+{
+
+    const WRAPPER = "Links";
+
+  /**
+  * Return all links
+  **/
+    public function index(Manager $fractal, Request $request)
+    {
+        $links  = LinkFound::all();
+        $collection = new Collection($links, new LinkFoundTransformer);
+
+        $fractal = new Manager;
+        $data = $fractal->createData($collection)->toArray();
+
+        return $this->respond($data);
+    }
+
+    /**
+    * Return links with descriptions based on a provided SourceArea value
+    **/
+    public function getLinksBySourceArea($sourceArea)
+    {
+        $links = DB::connection('copilot')
+            ->table('vw_LinkFound')
+            ->where('SourceArea', '=', str_replace("+", " ",$sourceArea))
+            ->select('LinkText', 'LinkDescr')
+            ->get();
+
+         $data = $links;
+        if (!is_null($links) && !$links->isEmpty()) {
+            //When using the Eloquent query builder, we must "hydrate" the results back to collection of objects
+            $links_hydrated = LinkFound::hydrate($links->toArray());
+            $collection = new Collection($links_hydrated, new LinkFoundTransformer, self::WRAPPER);
+
+            //set data serializer
+            $fractal = new Manager;
+            $fractal->setSerializer(new CustomDataArraySerializer);
+            $data = $fractal->createData($collection)->toArray();
+        }
+
+         return $this->respond($data);
+    }
+}

--- a/app/Http/Transformers/LinkFoundTransformer.php
+++ b/app/Http/Transformers/LinkFoundTransformer.php
@@ -1,0 +1,22 @@
+<?php namespace App\Http\Transformers;
+
+use App\Models\LinkFound;
+use League\Fractal\Resource\Collection;
+use League\Fractal\TransformerAbstract;
+
+class LinkFoundTransformer extends TransformerAbstract
+{
+
+    /**
+    * A Fractal transformer for a link. Defines how data for
+    * a link should be output in the API.
+    **/
+
+    public function transform(LinkFound $link)
+    {
+        return [
+            'Link'  =>  $link->LinkText,
+            'Description'  =>  $link->LinkDescr,
+        ];
+    }
+}

--- a/app/Models/LinkFound.php
+++ b/app/Models/LinkFound.php
@@ -1,0 +1,15 @@
+<?php namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class LinkFound extends Model
+{
+    /**
+    * Model for a link found by Funnelback Search
+    **/
+     protected $table = 'vw_LinkFound';
+     protected $connection = 'copilot';
+     protected $primaryKey = null;
+     public $timestamps = false;
+     public $incrementing = false;
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -70,6 +70,7 @@ Route::prefix('v1')->middleware('auth.basic:api-basic,clientid')->group(function
 });
 
 
+/* Additions by John begin */
 /**
  * Copilot Endpoints
  *
@@ -86,6 +87,7 @@ Route::prefix('v1')->middleware('auth.basic:api-basic,clientid')->group(function
 
     });
 });
+/* Additions by John end */
 
 /**
  * Protected Endpoints Available on Public Domain
@@ -126,6 +128,11 @@ Route::prefix('v1')->group(function () {
     Route::get('classes/{yqrid}/{subjectid}/{coursenum}', 'CourseYearQuarterController@getCourseYearQuarter');
 
     Route::get('schedules/{psclassid}', 'ClassScheduleController@getClassSchedules');
+
+    /* Additions by John begin */
+    // This is for Copilot Studio: Get an array of links and descriptions based on a provided SourceArea value
+    Route::get('linksfound/{sourcearea}', 'LinkFoundController@getLinksBySourceArea');
+    /* Additions by John end */
     
     //API endpoints specific to ModoLabs requirements
     /*Route::get('catalog/terms', 'YearQuarterController@getViewableYearQuarters');


### PR DESCRIPTION
The new linksfound endpoint is intended to be used in Copilot Studio, to read an array of links and their descriptions for a provided area of interest phrase.